### PR TITLE
Add host for this service so that redirect works in environments

### DIFF
--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -32,4 +32,5 @@ object ConfigKeys {
   val thresholdPreviousYearsUrl: String = "thresholdPreviousYearsUrl"
   val vatSubscription: String = "vat-subscription"
   val contactPreferences: String = "contact-preferences"
+  val host: String = "host"
 }

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -47,6 +47,7 @@ trait AppConfig extends ServicesConfig {
   val thresholdPreviousYearsUrl: String
   val vatSubscriptionHost: String
   val contactPreferencesHost: String
+  val host: String
   def feedbackUrl(redirect: String): String
 }
 
@@ -97,6 +98,9 @@ class FrontendAppConfig @Inject()(val runModeConfiguration: Configuration, envir
   override val thresholdPreviousYearsUrl: String = getString(Keys.thresholdPreviousYearsUrl)
   override val vatSubscriptionHost: String = baseUrl(Keys.vatSubscription)
   override val contactPreferencesHost: String = baseUrl(Keys.contactPreferences)
+
+
+  override val host: String = getString(Keys.host)
 
   override def feedbackUrl(redirect: String): String = s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier" +
     s"&backUrl=${ContinueUrl(redirect).encodedUrl}"

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -103,5 +103,5 @@ class FrontendAppConfig @Inject()(val runModeConfiguration: Configuration, envir
   override val host: String = getString(Keys.host)
 
   override def feedbackUrl(redirect: String): String = s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier" +
-    s"&backUrl=${ContinueUrl(redirect).encodedUrl}"
+    s"&backUrl=${ContinueUrl(host + redirect).encodedUrl}"
 }

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -67,7 +67,7 @@
   <div class="beta-banner">
     <p>
       <strong id="phase" class="phase-tag">@messages("betaBanner.phaseName")</strong>
-      <span>@messages("betaBanner.newService") <a id="beta-banner-feedback" href="@appConfig.feedbackUrl(afterFeedbackRedirect))">@messages("betaBanner.feedback")</a> @messages("betaBanner.feedbackImprove")</span>
+      <span>@messages("betaBanner.newService") <a id="beta-banner-feedback" href="@appConfig.feedbackUrl(afterFeedbackRedirect)">@messages("betaBanner.feedback")</a> @messages("betaBanner.feedbackImprove")</span>
     </p>
   </div>
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -117,6 +117,8 @@ assets {
   url = "http://localhost:9032/assets/"
 }
 
+host = "http://localhost:9166"
+
 contact-frontend {
   url = "http://localhost:9250"
 }

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -42,5 +42,8 @@ class MockAppConfig(val runModeConfiguration: Configuration, val mode: Mode = Mo
   override val contactPreferencesHost: String = "/test-contact-preferences-host"
   override val agentClientLookupServiceUrl: String = ""
   override val agentClientLookupServicePath: String = "/agent-client-lookup"
+
+  override val host: String = "localhost:9166"
+
   override def feedbackUrl(redirect: String): String = s"feedback/$redirect"
 }


### PR DESCRIPTION
- Since the change to using the contact feedback form the back links stopped appearing upon completion of the feedback.
- Contact only allows absolute redirect URLs that are within the correct domain (tax.service)
- The following PRs are necessary for them to function in the relevant environments
-- https://github.com/hmrc/app-config-development/pull/2033
-- https://github.com/hmrc/app-config-qa/pull/3782
-- https://github.com/hmrc/app-config-production/pull/3458
