### PR TITLE
[BTAT-8276] Removed unused auth-client dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ RoutesKeys.routesImport := Seq.empty
 val compile = Seq(
   "uk.gov.hmrc"             %% "govuk-template"           % "5.55.0-play-26",
   "uk.gov.hmrc"             %% "play-ui"                  % "8.10.0-play-26",
-  "uk.gov.hmrc"             %% "auth-client"              % "3.0.0-play-26",
   "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.8.0",
   "uk.gov.hmrc"             %% "play-language"            % "4.3.0-play-26",
   "com.typesafe.play"       %% "play-json-joda"           % "2.6.0-RC1",


### PR DESCRIPTION
There were no deprecated session keys or other values in the service so no other changes were needed